### PR TITLE
Different liveness/readiness endpoints, disable by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq_alive (2.0.0)
+    sidekiq_alive (2.0.1)
       sidekiq
       sinatra
 
@@ -13,7 +13,8 @@ GEM
     diff-lcs (1.3)
     method_source (0.9.2)
     mock_redis (0.19.0)
-    mustermann (1.0.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -40,6 +41,7 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.8.0)
+    ruby2_keywords (0.0.2)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -50,7 +52,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    tilt (2.0.9)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ bundle exec sidekiq
 
 ```
 curl localhost:7433
-#=> Alive!                                   
+#=> Alive!
 ```
 
 
-__how to disable?__
-You can disabled by setting `ENV` variable `DISABLE_SIDEKIQ_ALIVE`
+__How to enable?__
+You can eanble by setting `ENV` variable `SIDEKIQ_ALIVE`
 example:
 
 ```
-DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq
+SIDEKIQ_ALIVE=true bundle exec sidekiq
 ```
 
 ### Kubernetes setup
@@ -227,7 +227,7 @@ SidekiqAlive.setup do |config|
   # ==> Queue Prefix
   # SidekiqAlive will run in a independent queue for each instance/replica
   # This queue name will be generated with: "#{queue_prefix}-#{hostname}.
-  # You can customize the prefix here. 
+  # You can customize the prefix here.
   # default: :sidekiq_alive
   #
   #    config.queue_prefix = :other

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -81,7 +81,6 @@ module SidekiqAlive
   end
 
   def self.alive?
-    redis.ttl(current_lifeness_key) != -2
   end
 
   # CONFIG ---------------------------------------
@@ -104,6 +103,14 @@ module SidekiqAlive
 
   def self.hostname
     ENV['HOSTNAME'] || 'HOSTNAME_NOT_SET'
+  end
+
+  def self.ready?
+   redis.ttl(current_lifeness_key) != -2 && config.readiness_check.call
+  end
+
+  def self.alive?
+    config.liveness_check.call
   end
 
   def self.shutdown_info

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -80,9 +80,6 @@ module SidekiqAlive
     Sidekiq.redis { |r| r }
   end
 
-  def self.alive?
-  end
-
   # CONFIG ---------------------------------------
 
   def self.setup

--- a/lib/sidekiq_alive.rb
+++ b/lib/sidekiq_alive.rb
@@ -159,4 +159,4 @@ end
 require 'sidekiq_alive/worker'
 require 'sidekiq_alive/server'
 
-SidekiqAlive.start unless ENV['DISABLE_SIDEKIQ_ALIVE']
+SidekiqAlive.start if ENV['SIDEKIQ_ALIVE']

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -7,7 +7,10 @@ module SidekiqAlive
                   :time_to_live,
                   :callback,
                   :registered_instance_key,
-                  :queue_prefix
+                  :queue_prefix,
+                  :readiness_check,
+                  :liveness_check
+
 
     def initialize
       set_defaults
@@ -20,6 +23,8 @@ module SidekiqAlive
       @callback = proc {}
       @registered_instance_key = 'SIDEKIQ_REGISTERED_INSTANCE'
       @queue_prefix = :sidekiq_alive
+      @readiness_check = Proc.new { true }
+      @liveness_check = Proc.new { true }
     end
 
     def registration_ttl

--- a/lib/sidekiq_alive/config.rb
+++ b/lib/sidekiq_alive/config.rb
@@ -9,7 +9,8 @@ module SidekiqAlive
                   :registered_instance_key,
                   :queue_prefix,
                   :readiness_check,
-                  :liveness_check
+                  :liveness_check,
+                  :token
 
 
     def initialize
@@ -25,6 +26,7 @@ module SidekiqAlive
       @queue_prefix = :sidekiq_alive
       @readiness_check = Proc.new { true }
       @liveness_check = Proc.new { true }
+      @token = "here-be-leadfeeding-dragons"
     end
 
     def registration_ttl

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -4,9 +4,12 @@ module SidekiqAlive
     set :bind, '0.0.0.0'
     set :port, -> { SidekiqAlive.config.port }
 
-    get '/' do
-      status 404
-      body ""
+    before do
+      token = params["token"] || headers["TOKEN"]
+
+      unless Rack::Utils.secure_compare(token.to_s, SidekiqAlive.config.token)
+        halt 401
+      end
     end
 
     get '/-/liveness' do
@@ -27,6 +30,11 @@ module SidekiqAlive
         status 404
         body "KO"
       end
+    end
+
+    get '/*' do
+      status 404
+      body "did you mean /-/liveness or /-/readiness ?"
     end
   end
 end

--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -5,14 +5,27 @@ module SidekiqAlive
     set :port, -> { SidekiqAlive.config.port }
 
     get '/' do
+      status 404
+      body ""
+    end
+
+    get '/-/liveness' do
       if SidekiqAlive.alive?
         status 200
-        body 'Alive!'
+        body "OK"
       else
-        response = "Can't find the alive key"
-        SidekiqAlive.logger.error(response)
         status 404
-        body response
+        body "KO"
+      end
+    end
+
+    get '/-/readiness' do
+      if SidekiqAlive.ready?
+        status 200
+        body "OK"
+      else
+        status 404
+        body "KO"
       end
     end
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -6,18 +6,28 @@ RSpec.describe SidekiqAlive::Server do
   subject(:app) { described_class }
 
   describe 'responses' do
-    it "responds with success when the service is alive" do
-      allow(SidekiqAlive).to receive(:alive?) { true }
-      get '/'
-      expect(last_response).to be_ok
-      expect(last_response.body).to eq('Alive!')
+    describe "/-/liveness" do
+      it "responds with success" do
+        get '/-/liveness'
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('OK')
+      end
     end
 
-    it "responds with an error when the service is not alive" do
-      allow(SidekiqAlive).to receive(:alive?) { false }
-      get '/'
-      expect(last_response).not_to be_ok
-      expect(last_response.body).to eq("Can't find the alive key")
+    describe "/-/readiness" do
+      it "responds with ok if the service is ready" do
+        allow(SidekiqAlive).to receive(:ready?) { true }
+        get '/-/readiness'
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq("OK")
+      end
+
+      it "responds with an error when the service is not ready" do
+        allow(SidekiqAlive).to receive(:ready?) { false }
+        get '/-/readiness'
+        expect(last_response).not_to be_ok
+        expect(last_response.body).to eq("KO")
+      end
     end
   end
 
@@ -35,5 +45,4 @@ RSpec.describe SidekiqAlive::Server do
       expect( described_class.port ).to eq '4567'
     end
   end
-
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -5,28 +5,42 @@ RSpec.describe SidekiqAlive::Server do
 
   subject(:app) { described_class }
 
+  let(:token) { SidekiqAlive.config.token }
+
   describe 'responses' do
     describe "/-/liveness" do
       it "responds with success" do
-        get '/-/liveness'
+        get "/-/liveness?token=#{token}"
         expect(last_response).to be_ok
         expect(last_response.body).to eq('OK')
+      end
+
+      it "responds with 401 if token is invalid" do
+        get "/-/liveness?token=foo"
+        expect(last_response).not_to be_ok
+        expect(last_response.body).to eq("")
       end
     end
 
     describe "/-/readiness" do
       it "responds with ok if the service is ready" do
         allow(SidekiqAlive).to receive(:ready?) { true }
-        get '/-/readiness'
+        get "/-/readiness?token=#{token}"
         expect(last_response).to be_ok
         expect(last_response.body).to eq("OK")
       end
 
       it "responds with an error when the service is not ready" do
         allow(SidekiqAlive).to receive(:ready?) { false }
-        get '/-/readiness'
+        get "/-/readiness?token=#{token}"
         expect(last_response).not_to be_ok
         expect(last_response.body).to eq("KO")
+      end
+
+      it "responds with 401 if token is invalid" do
+        get "/-/readiness?token=foo"
+        expect(last_response).not_to be_ok
+        expect(last_response.body).to eq("")
       end
     end
   end

--- a/spec/sidekiq_alive_spec.rb
+++ b/spec/sidekiq_alive_spec.rb
@@ -64,10 +64,14 @@ RSpec.describe SidekiqAlive do
   end
 
   it "::alive?" do
-    redis = SidekiqAlive.redis
-    expect(SidekiqAlive.alive?).to be false
-    SidekiqAlive.store_alive_key
     expect(SidekiqAlive.alive?).to be true
+  end
+
+  it "::ready?" do
+    redis = SidekiqAlive.redis
+    expect(SidekiqAlive.ready?).to be false
+    SidekiqAlive.store_alive_key
+    expect(SidekiqAlive.ready?).to be true
   end
 
   it "::registered_instances" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,5 +22,7 @@ RSpec.configure do |config|
   config.before do
     SidekiqAlive.redis.flushall
     SidekiqAlive.config.set_defaults
+
+    Sidekiq.logger= Logger.new("/dev/null")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,6 @@ RSpec.configure do |config|
     SidekiqAlive.redis.flushall
     SidekiqAlive.config.set_defaults
 
-    Sidekiq.logger= Logger.new("/dev/null")
+    Sidekiq.logger = Logger.new("/dev/null")
   end
 end


### PR DESCRIPTION
Related: https://github.com/Leadfeeder/issue-tracker/issues/11973

- Adds 2 endpoints:
  - `/-/liveness`
  - `/-/readiness`
- Makes both endpoints configurable for custom checks in app
- Disables SidekiqAlive process by default