### PR TITLE
Handle duplicate token headers

### DIFF
--- a/lib/sidekiq_alive/server.rb
+++ b/lib/sidekiq_alive/server.rb
@@ -7,7 +7,8 @@ module SidekiqAlive
     set :logger, SidekiqAlive.config.server_logger
 
     before do
-      token = params["token"] || request.env["HTTP_TOKEN"]
+      token = params["token"] || request.env["HTTP_TOKEN"] || ""
+      token = token.split(",")[0]
 
       unless Rack::Utils.secure_compare(token.to_s, SidekiqAlive.config.token)
         halt 401

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe SidekiqAlive::Server do
       end
 
       it "responds with success when the token header is duplicated" do
-        header 'TOKEN', token
-        header 'TOKEN', token
+        header 'TOKEN', "#{token},#{token}"
         get "/-/liveness"
         expect(last_response).to be_ok
         expect(last_response.body).to eq('OK')
@@ -55,8 +54,7 @@ RSpec.describe SidekiqAlive::Server do
 
       it "responds with ok if the service is ready and the token header is duplicated" do
         allow(SidekiqAlive).to receive(:ready?) { true }
-        header 'TOKEN', token
-        header 'TOKEN', token
+        header 'TOKEN', "#{token},#{token}"
         get "/-/readiness"
         expect(last_response).to be_ok
         expect(last_response.body).to eq("OK")

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe SidekiqAlive::Server do
         expect(last_response.body).to eq('OK')
       end
 
+      it "responds with success when the token header is duplicated" do
+        header 'TOKEN', token
+        header 'TOKEN', token
+        get "/-/liveness"
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq('OK')
+      end
+
       it "responds with 401 if token is invalid" do
         get "/-/liveness?token=foo"
         expect(last_response).not_to be_ok
@@ -39,6 +47,15 @@ RSpec.describe SidekiqAlive::Server do
 
       it "responds with ok if the service is ready and the token header is used" do
         allow(SidekiqAlive).to receive(:ready?) { true }
+        header 'TOKEN', token
+        get "/-/readiness"
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq("OK")
+      end
+
+      it "responds with ok if the service is ready and the token header is duplicated" do
+        allow(SidekiqAlive).to receive(:ready?) { true }
+        header 'TOKEN', token
         header 'TOKEN', token
         get "/-/readiness"
         expect(last_response).to be_ok


### PR DESCRIPTION
Istio has a bug where it passes in probe headers twice. This PR only looks at the first value.

Part of https://github.com/Leadfeeder/issue-tracker/issues/13428